### PR TITLE
Update rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CACHE_NAME: cache_v0
 
 jobs:
   check:
@@ -25,24 +24,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    env:
-      # https://doc.rust-lang.org/cargo/reference/profiles.html#release
-      # https://doc.rust-lang.org/cargo/reference/environment-variables.html
-      CARGO_INCREMENTAL: 1
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        # https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-build-${{ env.CACHE_NAME }}-${{ github.run_id }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-build-${{ env.CACHE_NAME }}
     - name: Build
       run: cargo build --release --examples --verbose
 
@@ -90,17 +73,6 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-build-${{ env.CACHE_NAME }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-${{ env.CACHE_NAME }}
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -118,17 +90,6 @@ jobs:
         python-version: '3.x'
     - name: Install oj
       run: pip3 install --upgrade setuptools wheel pip && pip3 install online-judge-tools && oj --version
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-build-${{ env.CACHE_NAME }}-${{ github.run_id }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-build-${{ env.CACHE_NAME }}
     - name: Run tests
       run: RUST_LOG='info' cargo run --bin oj_test -- ${{ matrix.range }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -21,13 +22,6 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --release --examples --verbose
 
   clippy:
     runs-on: ubuntu-latest
@@ -59,7 +53,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: build
     env:
       RUST_LOG: info
     steps:
@@ -82,7 +75,8 @@ jobs:
     strategy:
       matrix:
         range: [0-2, 2-4, 4-6, 6-8, 8-10]
-    needs: build
+    env:
+      RUST_LOG: info
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -90,8 +84,18 @@ jobs:
         python-version: '3.x'
     - name: Install oj
       run: pip3 install --upgrade setuptools wheel pip && pip3 install online-judge-tools && oj --version
-    - name: Run tests
-      run: RUST_LOG='info' cargo run --bin oj_test -- ${{ matrix.range }}
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+    - name: Release build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build --release --examples --verbose
+    - name: oj test
+      uses: actions-rs/cargo@v1
+      with:
+        command: run --bin oj_test -- ${{ matrix.range }}
 
   publish-doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,11 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+      - name: Release build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --examples --verbose
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,7 +91,8 @@ jobs:
     - name: Release build
       uses: actions-rs/cargo@v1
       with:
-        command: build --release --examples --verbose
+        command: build
+        args: --release --examples --verbose
     - name: oj test
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,7 +95,8 @@ jobs:
     - name: oj test
       uses: actions-rs/cargo@v1
       with:
-        command: run --bin oj_test -- ${{ matrix.range }}
+        command: run
+        args: --bin oj_test -- ${{ matrix.range }}
 
   publish-doc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
build cache を共有してもたいして oj-test が速くならなかったため、  
素朴に `cargo build --release && cargo run --bin oj-test` とする