### PR TITLE
oj を使うユニットテストを ignore

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,24 +53,12 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    env:
-      RUST_LOG: info
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-      - name: Install oj
-        run: pip3 install --upgrade setuptools wheel pip && pip3 install online-judge-tools && oj --version
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
-      - name: Release build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --examples --verbose
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/oj_test/tests/test.rs
+++ b/oj_test/tests/test.rs
@@ -19,6 +19,7 @@ impl Testcase for LocalTestcase {
 }
 
 #[test]
+#[ignore]
 fn local_testcase() {
     env_logger::init();
 


### PR DESCRIPTION
`cargo test` の前に `cargo build --release --examples` が必要なのはつらいので解消