### PR TITLE
[arithmetic series] 128bit integer

### DIFF
--- a/algo/arithmetic_series/src/lib.rs
+++ b/algo/arithmetic_series/src/lib.rs
@@ -56,7 +56,7 @@ macro_rules! impl_int {
     };
 }
 
-impl_int!(i32, i64, u32, u64, usize);
+impl_int!(i32, i64, i128, u32, u64, u128, usize);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
64 bit に収まらないが 128 bit に収まる計算が時々あるので等差数列の和を `i128`, `u128` に対応させる

問題例: https://atcoder.jp/contests/abc269/tasks/abc269_f