### PR TITLE
Fenwick tree の初期化バグ修正

### DIFF
--- a/algo/fenwick_tree/src/lib.rs
+++ b/algo/fenwick_tree/src/lib.rs
@@ -1,7 +1,7 @@
 use std::ops::Range;
 
 /// Fenwick Tree (Binary Indexed Tree) [http://hos.ac/slides/20140319_bit.pdf](http://hos.ac/slides/20140319_bit.pdf)
-/// 
+///
 /// # Examples
 /// ```
 /// use fenwick_tree::FenwickTree;

--- a/algo/fenwick_tree/src/lib.rs
+++ b/algo/fenwick_tree/src/lib.rs
@@ -15,11 +15,14 @@ where
     /// 長さ `n` の列を作り、初期値 `e` で埋めます。雰囲気は `let mut a = vec![e; n];` です。
     pub fn new(n: usize, e: T) -> Self {
         let n = n.next_power_of_two();
-        Self {
-            n,
-            e,
-            dat: vec![e; n + 1],
+        let mut dat = vec![e; n + 1];
+        for i in (2..=n).step_by(2) {
+            let j = 1 << (i.trailing_zeros() - 1);
+            let mut y = dat[j];
+            y += dat[j];
+            dat[i] = y; // dat[j] * 2
         }
+        Self { n, e, dat }
     }
     // 0-indexed
     // a[k] += x

--- a/algo/fenwick_tree/src/lib.rs
+++ b/algo/fenwick_tree/src/lib.rs
@@ -1,5 +1,22 @@
 use std::ops::Range;
 
+/// Fenwick Tree (Binary Indexed Tree) [http://hos.ac/slides/20140319_bit.pdf](http://hos.ac/slides/20140319_bit.pdf)
+/// 
+/// # Examples
+/// ```
+/// use fenwick_tree::FenwickTree;
+/// let mut ft = FenwickTree::new(5, 0);
+/// ft.add(0, 1);
+/// ft.add(2, 10);
+/// ft.add(4, 100);
+/// // [1, 0, 10, 0, 100]
+/// assert_eq!(ft.sum(0..1), 1);
+/// assert_eq!(ft.sum(0..2), 1);
+/// assert_eq!(ft.sum(0..3), 11);
+/// assert_eq!(ft.sum(2..4), 10);
+/// assert_eq!(ft.sum(2..5), 110);
+/// assert_eq!(ft.sum(0..5), 111);
+/// ```
 pub struct FenwickTree<T> {
     n: usize,
     e: T,
@@ -12,7 +29,6 @@ where
     T: std::ops::AddAssign,
     T: std::ops::SubAssign,
 {
-    /// 長さ `n` の列を作り、初期値 `e` で埋めます。雰囲気は `let mut a = vec![e; n];` です。
     pub fn new(n: usize, e: T) -> Self {
         let n = n.next_power_of_two();
         let mut dat = vec![e; n + 1];
@@ -26,7 +42,6 @@ where
     }
     // 0-indexed
     // a[k] += x
-    /// 列の `k` 番目に `x` を足します。`k` は 0-indexed です。`a[k] += x;`
     pub fn add(&mut self, k: usize, x: T) {
         assert!(k < self.n);
         let mut k = k + 1;
@@ -49,22 +64,6 @@ where
     }
     // 0-indexed
     // a[l] + a[l + 1] + ... + a[r - 1]
-    /// 区間和を計算します。`range` が `l..r` だとして `a[l..r].iter().sum::<T>()` です。
-    /// # Examples
-    /// ```
-    /// use fenwick_tree::FenwickTree;
-    /// let mut ft = FenwickTree::new(5, 0);
-    /// ft.add(0, 1);
-    /// ft.add(2, 10);
-    /// ft.add(4, 100);
-    /// // [1, 0, 10, 0, 100]
-    /// assert_eq!(ft.sum(0..1), 1);
-    /// assert_eq!(ft.sum(0..2), 1);
-    /// assert_eq!(ft.sum(0..3), 11);
-    /// assert_eq!(ft.sum(2..4), 10);
-    /// assert_eq!(ft.sum(2..5), 110);
-    /// assert_eq!(ft.sum(0..5), 111);
-    /// ```
     pub fn sum(&self, range: Range<usize>) -> T {
         let (l, r) = (range.start, range.end);
         assert!(r <= self.n);

--- a/algo/fenwick_tree/src/lib.rs
+++ b/algo/fenwick_tree/src/lib.rs
@@ -81,8 +81,9 @@ mod tests {
         let mut rng = thread_rng();
         for _ in 0..100 {
             let n: usize = rng.gen_range(1, 20);
-            let mut a = vec![0; n];
-            let mut ft = FenwickTree::new(n, 0);
+            let e = rng.gen_range(-100, 100);
+            let mut a = vec![e; n];
+            let mut ft = FenwickTree::new(n, e);
             for _ in 0..100 {
                 let i: usize = rng.gen_range(0, n);
                 let x: i32 = rng.gen_range(-100, 100);


### PR DESCRIPTION
初期値を 0 以外で

```rs
FenwickTree::new(n, 1);
```

のように初期化するときにバグがあった。